### PR TITLE
EndOfRoundInfoMessage sollte besser StichInfoMessage erweitern

### DIFF
--- a/src/main/java/ch/ntb/jass/common/proto/server_info_messages/EndOfRoundInfoMessage.java
+++ b/src/main/java/ch/ntb/jass/common/proto/server_info_messages/EndOfRoundInfoMessage.java
@@ -9,7 +9,7 @@ import ch.ntb.jass.common.entities.ScoreEntity;
  * @param gameOver If the score has reached the limit, gameOver is true and the game is finished.
  */
 
-public class EndOfRoundInfoMessage extends TurnInfoMessage {
+public class EndOfRoundInfoMessage extends StichInfoMessage {
 	public ScoreEntity score;
 	public boolean gameOver;
 }


### PR DESCRIPTION
Durch die neue StichInfoMessage mach das erweitern von TurnInfoMessage nicht mehr viel Sinn